### PR TITLE
Add generic inventory system with SVG item pickups

### DIFF
--- a/inventory.gd
+++ b/inventory.gd
@@ -1,0 +1,21 @@
+extends Node
+class_name Inventory
+
+var items: Dictionary = {}
+
+func add_item(name: String, icon: Texture2D, quantity: int = 1) -> void:
+    if items.has(name):
+        items[name]["quantity"] += quantity
+    else:
+        items[name] = {
+            "icon": icon,
+            "quantity": quantity,
+        }
+
+func get_quantity(name: String) -> int:
+    if items.has(name):
+        return items[name]["quantity"]
+    return 0
+
+func get_items() -> Dictionary:
+    return items.duplicate(true)

--- a/item.gd
+++ b/item.gd
@@ -1,0 +1,13 @@
+extends Area3D
+
+@export var item_name: String = "Generic Item"
+@export var icon: Texture2D = preload("res://item_icon.svg")
+@export var quantity: int = 1
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+
+func _on_body_entered(body: Node) -> void:
+    if body.has_method("pick_up_item"):
+        body.pick_up_item(self)
+        queue_free()

--- a/item.tscn
+++ b/item.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://item.gd" type="Script" id=1]
+[ext_resource path="res://item_icon.svg" type="Texture2D" id=2]
+
+[sub_resource type="SphereShape3D" id=1]
+
+[node name="Item" type="Area3D"]
+script = ExtResource(1)
+icon = ExtResource(2)
+item_name = "Generic Item"
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource(1)
+
+[node name="Sprite3D" type="Sprite3D" parent="."]
+texture = ExtResource(2)

--- a/item_icon.svg
+++ b/item_icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#ffcc00" stroke="#000000" stroke-width="2"/>
+</svg>

--- a/player.gd
+++ b/player.gd
@@ -12,21 +12,22 @@ var current_path_index: int = 0
 var target_position: Vector3
 var is_moving: bool = false
 var current_tree = null
+var inventory: Inventory = Inventory.new()
 
 @onready var terrain_generator = get_parent()
 @onready var rig = $Rig
 @onready var animation_player = $AnimationPlayer
 
 func _ready():
-	animation_player.play("Idle")
-	pathfinder = Pathfinder.new()
-	
-	await get_tree().process_frame
-	pathfinder.setup(terrain_generator)
-	
-	snap_to_terrain()
-	
-	print("Player ready, pathfinder initialized")
+        animation_player.play("Idle")
+        pathfinder = Pathfinder.new()
+
+        await get_tree().process_frame
+        pathfinder.setup(terrain_generator)
+
+        snap_to_terrain()
+
+        print("Player ready, pathfinder initialized")
 
 # Method 1A: Use terrain tile data directly
 func snap_to_terrain():
@@ -155,12 +156,16 @@ func start_cutting_tree(tree):
 	finish_cutting_tree()
 
 func finish_cutting_tree():
-	"""Complete tree cutting"""
-	if current_tree:
-		print("Tree cut down!")
-		current_tree.queue_free()
-		current_tree = null
-		animation_player.play("Idle")
+        """Complete tree cutting"""
+        if current_tree:
+                print("Tree cut down!")
+                current_tree.queue_free()
+                current_tree = null
+                animation_player.play("Idle")
+
+func pick_up_item(item) -> void:
+        inventory.add_item(item.item_name, item.icon, item.quantity)
+        print("Picked up %s" % item.item_name)
 
 # Debug functions
 func get_current_path() -> Array:

--- a/tests/inventory_test.gd
+++ b/tests/inventory_test.gd
@@ -1,0 +1,19 @@
+extends SceneTree
+
+const Inventory = preload("res://inventory.gd")
+
+func _init():
+    var inv = Inventory.new()
+    var file = FileAccess.open("res://item_icon.svg", FileAccess.READ)
+    inv.add_item("Generic Item", null)
+    if file and inv.get_quantity("Generic Item") == 1:
+        file.close()
+        inv.free()
+        print("Inventory add item test passed")
+        quit(0)
+    else:
+        if file:
+            file.close()
+        inv.free()
+        push_error("Inventory add item test failed")
+        quit(1)


### PR DESCRIPTION
## Summary
- add `Inventory` class to track items and quantities
- create generic pickup `Item` scene with SVG icon
- wire player to collect items and expand tests for inventory

## Testing
- `godot --headless -s tests/inventory_test.gd`
- `godot --headless -s tests/resource_loading_test.gd`


------
https://chatgpt.com/codex/tasks/task_e_689e2511e4888324bd563a415037d520